### PR TITLE
Add ability to use transit-movements-converter to get a Json message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Create example NCTS messages.  Contents will be valid according to the XSD files but are not guaranteed to be valid because some elements depend on other contents - see DDNA rules.
 
 Start locally
-```aidl
+```
 sbt run
 ```
 
@@ -12,6 +12,9 @@ Example use
 ```
 curl -X POST http://localhost:9000/messages/CC015B -o CC015B.xml
 ```
+
+By default, the message is returned in XML. If you wish for Json to be returned, set the `Accept` header to `application/json`. You will need to be running `transit-movements-converter` locally to do so.
+Note that only some messages can be converted into Json (specifically, phase 5 messages), a 406 error code will be returned if a message cannot be returned as Json.
 
 ### License
 

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.Configuration
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppConfig @Inject() (servicesConfig: ServicesConfig) {
+
+  val converterUrl = servicesConfig.baseUrl("transit-movements-converter")
+
+}

--- a/app/connector/ConverterConnector.scala
+++ b/app/connector/ConverterConnector.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connector
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import com.google.inject.Inject
+import config.AppConfig
+import models.MessageType
+import models.error.ConversionError
+import play.api.Logging
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
+import play.api.http.Status.OK
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.StringContextOps
+import uk.gov.hmrc.http.client.HttpClientV2
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+class ConverterConnector @Inject()(appConfig: AppConfig, httpClient: HttpClientV2)(implicit ec: ExecutionContext, materializer: Materializer) extends Logging {
+
+  private def converterUrl(messageType: String) =
+    s"${appConfig.converterUrl}/transit-movements-converter/messages/$messageType"
+
+  def convert(messageType: MessageType, input: String): EitherT[Future, ConversionError, Source[ByteString, _]] = {
+    EitherT(
+      Future.successful(
+        messageType.converterType.toRight(ConversionError.noConversionExists(messageType))
+      )
+    )
+    .flatMap {
+      messageType =>
+        EitherT(
+          httpClient
+            .post(url"${converterUrl(messageType)}")(HeaderCarrier())
+            .setHeader(HeaderNames.CONTENT_TYPE -> MimeTypes.XML)
+            .setHeader(HeaderNames.ACCEPT -> MimeTypes.JSON)
+            .withBody(input)
+            .stream[HttpResponse]
+            .flatMap {
+              response =>
+                response.status match {
+                  case OK => Future.successful(Right(response.bodyAsSource))
+                  case _ =>
+                    response
+                      .bodyAsSource
+                      .reduce(_ ++ _)
+                      .map(_.utf8String)
+                      .runWith(Sink.head)
+                      .map {
+                        result =>
+                          logger.error(s"Failed to convert: $result, status code ${response.status}")
+                          Left(ConversionError.unexpected("Internal service error"))
+                      }
+                }
+            }
+        )
+    }
+  }
+
+}

--- a/app/models/MessageType.scala
+++ b/app/models/MessageType.scala
@@ -25,7 +25,8 @@ import scala.collection.immutable.ListSet
 sealed abstract class MessageType(
   val rootNode: String,
   val templateFile: String,
-  val templateArgGen: Gen[JsObject]
+  val templateArgGen: Gen[JsObject],
+  val converterType: Option[String] = None
 ) extends Product
     with Serializable
 
@@ -42,7 +43,7 @@ object MessageType {
   case object CC014C extends MessageType("CC014C", "cc014c.njk", Phase5Generators.cc014cGen)
 
   case object CC015B extends MessageType("CC015B", "cc015b.njk", Phase4Generators.cc015bGen)
-  case object CC015C extends MessageType("CC015C", "cc015c.njk", Phase5Generators.cc015cGen)
+  case object CC015C extends MessageType("CC015C", "cc015c.njk", Phase5Generators.cc015cGen, Some("IE015"))
 
   case object CD034A extends MessageType("CD034A", "cd034a.njk", Phase4Generators.cd034aGen)
   case object CD037A extends MessageType("CD037A", "cd037a.njk", Phase4Generators.cd037aGen)

--- a/app/models/error/ConversionError.scala
+++ b/app/models/error/ConversionError.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.error
+
+import models.MessageType
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_ACCEPTABLE
+
+case class ConversionError (statusCode: Int, message: String)
+
+object ConversionError {
+  def unexpected(message: String) =
+    ConversionError(INTERNAL_SERVER_ERROR, s"An unexpected error occurred: $message")
+
+  def noConversionExists(messageType: MessageType) =
+    ConversionError(NOT_ACCEPTABLE, s"The message type ${messageType.rootNode} cannot be converted to Json")
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,6 +34,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
+
 appName = "transit-movements-message-generator"
 play.http.router = prod.Routes
 
@@ -60,6 +62,12 @@ microservice {
     auth {
       host = localhost
       port = 8500
+    }
+
+    transit-movements-converter {
+      protocol = http
+      host = localhost
+      port = 9475
     }
   }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % "5.16.0",
+    "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % "6.3.0",
     "uk.gov.hmrc"          %% "play-nunjucks"             % "0.33.0-play-28",
     "org.typelevel"        %% "cats-core"                 % "2.6.1",
     "org.scalacheck"       %% "scalacheck"                % "1.15.4",


### PR DESCRIPTION
For CTCP-1025, I needed to generate a message in Json -- this adds the ability to convert the XML into Json using our converter directly from the generator.

There is no test project, probably because this project was meant to be internal only, but there has been talk about using it as part of the test support API, so tests might natrually come anyway.